### PR TITLE
兼容mineru 2.0远程调用官方服务

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -6,7 +6,7 @@ tabulate==0.9.0
 Werkzeug==3.1.3
 PyJWT==2.10.1
 dotenv==0.9.9
-magic-pdf[full]==1.3.10
+mineru
 transformers==4.51.3
 elasticsearch==8.12.0
 minio==7.2.4


### PR DESCRIPTION
添加兼容mineru 2.0官方sglang代码，将原有打包的mineru服务去除

使用方式：
1. 使用官方给出的Dockerfile启动sglang server
```
wget https://gcore.jsdelivr.net/gh/opendatalab/MinerU@master/docker/global/Dockerfile
docker build -t mineru-sglang:latest -f Dockerfile .

docker run --gpus all \
  --shm-size 32g \
  -p 30000:30000 \
  --ipc=host \
  mineru-sglang:latest \
  mineru-sglang-server --host 0.0.0.0 --port 30000
```
2. 配置环境变量 MINERU_SERVER_URL=http://127.0.0.1:30000