### PR TITLE
修复 Star History 图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ sudo systemctl restart docker
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=knowflow-ai/KnowFlow&type=Date)](https://star-history.com/#knowflow-ai/KnowFlow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=knowflow-ai/KnowFlow&type=Date)](https://star-history.dera.page/#knowflow-ai/KnowFlow&Date)
 
 如果这个项目对您有帮助，欢迎点个 Star
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@
 
 # KnowFlow - 企业级智能知识库解决方案
 
-[![Star History Chart](https://api.star-history.com/svg?repos=weizxfree/KnowFlow&type=Date)](https://star-history.com/#weizxfree/KnowFlow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=weizxfree/KnowFlow&type=Date)](https://star-history.dera.page/#weizxfree/KnowFlow&Date)
 
 🌐 **官方网站**: [https://www.knowflowchat.cn/](https://www.knowflowchat.cn/)
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub stargazer API 限制已经无法正常加载，Star 数据无法展示。

本次修改：
- 将 README.md 和 docker/README.md 中的 Star History 图表切换到可用的数据源
- 恢复 Star 趋势图表的正常显示

请检查并合并，谢谢！